### PR TITLE
Relax name validation in PostConfigure method

### DIFF
--- a/src/Nerdolando.Bff.AspNetCore/Options/BffPostConfigureOptions.cs
+++ b/src/Nerdolando.Bff.AspNetCore/Options/BffPostConfigureOptions.cs
@@ -10,7 +10,8 @@ namespace Nerdolando.Bff.AspNetCore.Options
         public void PostConfigure(string? name, TOptions options)
         {
             ArgumentNullException.ThrowIfNull(options);
-            ArgumentNullException.ThrowIfNullOrEmpty(name);
+            if(string.IsNullOrWhiteSpace(name))
+                return;
 
             var handler = _configureHandlerProvider.GetHandlerForOptions<TOptions>();
             if (handler == null)


### PR DESCRIPTION
Replaced ArgumentNullException.ThrowIfNullOrEmpty(name) with a check for string.IsNullOrWhiteSpace(name). The method now returns early instead of throwing an exception, improving tolerance for null, empty, or whitespace scheme names.